### PR TITLE
Activa log_errors por defecto

### DIFF
--- a/7.2/php.ini
+++ b/7.2/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On

--- a/7.3/php.ini
+++ b/7.3/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On

--- a/7.4/php.ini
+++ b/7.4/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On

--- a/8.0/php.ini
+++ b/8.0/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On

--- a/8.1/php.ini
+++ b/8.1/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On

--- a/8.2/php.ini
+++ b/8.2/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On

--- a/8.3/php.ini
+++ b/8.3/php.ini
@@ -6,3 +6,4 @@ memory_limit=${PHP_MEMORY_LIMIT}
 max_execution_time=${PHP_MAX_EXECUTION_TIME}
 max_input_time=${PHP_MAX_INPUT_TIME}
 short_open_tag=Off
+log_errors=On


### PR DESCRIPTION
Configura log_errors para que los errores se muestren también en los logs del contenedor. Por ejemplo:

$ docker compose logs php.local
php.local-1  | 172.20.0.2 -  26/Jun/2024:13:51:55 +0200 "GET /pinfo.php" 200
php.local-1  | NOTICE: PHP message: PHP Parse error:  syntax error, unexpected token "=" in /app/public/pinfo.php on line 5
